### PR TITLE
Merge changes from main repository into FlyBlind

### DIFF
--- a/src/Config.c
+++ b/src/Config.c
@@ -88,6 +88,7 @@ Sp_Units:  1     ; Speech units\r\n\
 Sp_Rate:   0     ; Speech rate (s)\r\n\
                  ;   0 = No speech\r\n\
 Sp_Dec:    0     ; Decimal places for speech\r\n\
+Sp_Volume: 6     ; 0 (min) to 8 (max)\r\n\
 \r\n\
 ; Thresholds\r\n\
 \r\n\
@@ -147,6 +148,7 @@ static const char Config_Sp_Mode[] PROGMEM    = "Sp_Mode";
 static const char Config_Sp_Units[] PROGMEM   = "Sp_Units";
 static const char Config_Sp_Rate[] PROGMEM    = "Sp_Rate";
 static const char Config_Sp_Dec[] PROGMEM     = "Sp_Dec";
+static const char Config_Sp_Volume[] PROGMEM  = "Sp_Volume";
 static const char Config_V_Thresh[] PROGMEM   = "V_Thresh";
 static const char Config_H_Thresh[] PROGMEM   = "H_Thresh";
 static const char Config_Use_SAS[] PROGMEM    = "Use_SAS";
@@ -236,6 +238,7 @@ void Config_Read(void)
 		HANDLE_VALUE(Config_Sp_Units,  UBX_sp_units,     val, val >= 0 && val <= 1);
 		HANDLE_VALUE(Config_Sp_Rate,   UBX_sp_rate,      val * 1000, val >= 0 && val <= 32);
 		HANDLE_VALUE(Config_Sp_Dec,    UBX_sp_decimals,  val, val >= 0 && val <= 2);
+		HANDLE_VALUE(Config_Sp_Volume, Tone_sp_volume,   8 - val, val >= 0 && val <= 8);
 		HANDLE_VALUE(Config_V_Thresh,  UBX_threshold,    val, TRUE);
 		HANDLE_VALUE(Config_H_Thresh,  UBX_hThreshold,   val, TRUE);
 		HANDLE_VALUE(Config_Use_SAS,   UBX_use_sas,      val, val == 0 || val == 1);

--- a/src/Config.c
+++ b/src/Config.c
@@ -121,9 +121,9 @@ TZ_Offset: 0     ; Timezone offset of output files in seconds\r\n\
 ;          level.\r\n\
 \r\n\
 Window:        0 ; Alarm window (m)\r\n\
-DZ_Elev:       0 ; Ground elevation (m)\r\n\
+DZ_Elev:       0 ; Ground elevation (m above sea level)\r\n\
 \r\n\
-Alarm_Elev: 1000 ; Alarm elevation (m)\r\n\
+Alarm_Elev: 1000 ; Alarm elevation (m above ground level)\r\n\
 Alarm_Type:    0 ; Alarm type\r\n\
                  ;   0 = No alarm\r\n\
                  ;   1 = Beep\r\n\

--- a/src/Config.c
+++ b/src/Config.c
@@ -88,7 +88,7 @@ Sp_Units:  1     ; Speech units\r\n\
 Sp_Rate:   0     ; Speech rate (s)\r\n\
                  ;   0 = No speech\r\n\
 Sp_Dec:    0     ; Decimal places for speech\r\n\
-Sp_Volume: 6     ; 0 (min) to 8 (max)\r\n\
+Sp_Volume: 8     ; 0 (min) to 8 (max)\r\n\
 \r\n\
 ; Thresholds\r\n\
 \r\n\

--- a/src/Config.c
+++ b/src/Config.c
@@ -121,6 +121,7 @@ TZ_Offset: 0     ; Timezone offset of output files in seconds\r\n\
 ;          level.\r\n\
 \r\n\
 Window:        0 ; Alarm window (m)\r\n\
+DZ_Elev:       0 ; Ground elevation (m)\r\n\
 \r\n\
 Alarm_Elev: 1000 ; Alarm elevation (m)\r\n\
 Alarm_Type:    0 ; Alarm type\r\n\
@@ -151,6 +152,7 @@ static const char Config_V_Thresh[] PROGMEM   = "V_Thresh";
 static const char Config_H_Thresh[] PROGMEM   = "H_Thresh";
 static const char Config_Use_SAS[] PROGMEM    = "Use_SAS";
 static const char Config_Window[] PROGMEM     = "Window";
+static const char Config_DZ_Elev[] PROGMEM    = "DZ_Elev";
 static const char Config_Alarm_Elev[] PROGMEM = "Alarm_Elev";
 static const char Config_Alarm_Type[] PROGMEM = "Alarm_Type";
 static const char Config_TZ_Offset[] PROGMEM  = "TZ_Offset";
@@ -175,6 +177,7 @@ void Config_Read(void)
 	char    *result;
 	
 	int32_t val;
+	int32_t dz_elev;
 
 	FRESULT res;
 	
@@ -240,13 +243,14 @@ void Config_Read(void)
 		HANDLE_VALUE(Config_H_Thresh,  UBX_hThreshold,   val, TRUE);
 		HANDLE_VALUE(Config_Use_SAS,   UBX_use_sas,      val, val == 0 || val == 1);
 		HANDLE_VALUE(Config_Window,    UBX_alarm_window, val * 1000, TRUE);
+		HANDLE_VALUE(Config_DZ_Elev,   dz_elev,          val * 1000, TRUE);
 		HANDLE_VALUE(Config_TZ_Offset, Log_tz_offset,    val, TRUE);
 		
 		#undef HANDLE_VALUE
 		
 		if (!strcmp_P(name, Config_Alarm_Elev))
 		{
-			UBX_alarms[UBX_num_alarms].elev = val * 1000;
+			UBX_alarms[UBX_num_alarms].elev = val * 1000 + dz_elev;
 		}
 		if (!strcmp_P(name, Config_Alarm_Type) && val != 0)
 		{

--- a/src/Config.c
+++ b/src/Config.c
@@ -97,7 +97,7 @@ Sp_Units:  2     ; Speech units\r\n\
                  ;   2 = kn\r\n\
 Sp_Rate:   8     ; Speech rate (s)\r\n\
                  ;   0 = No speech\r\n\
-Sp_Dec:    0     ; Decimal places for speech\r\n\
+Sp_Dec:    1     ; Decimal places for speech (0-2)\r\n\
                  ;   (Sp_Modes 0-4) \r\n\
 Sp_Volume: 8     ; 0 (min) to 8 (max)\r\n\
 \r\n\

--- a/src/Config.c
+++ b/src/Config.c
@@ -99,7 +99,7 @@ Sp_Rate:   8     ; Speech rate (s)\r\n\
                  ;   0 = No speech\r\n\
 Sp_Dec:    0     ; Decimal places for speech\r\n\
                  ;   (Sp_Modes 0-4) \r\n\
-Sp_Volume: 6     ; 0 (min) to 8 (max)\r\n\
+Sp_Volume: 8     ; 0 (min) to 8 (max)\r\n\
 \r\n\
 ; Thresholds\r\n\
 \r\n\

--- a/src/Config.c
+++ b/src/Config.c
@@ -97,8 +97,9 @@ Sp_Units:  2     ; Speech units\r\n\
                  ;   2 = kn\r\n\
 Sp_Rate:   8     ; Speech rate (s)\r\n\
                  ;   0 = No speech\r\n\
-Sp_Dec:    1     ; Decimal places for speech (0-2)\r\n\
+Sp_Dec:    0     ; Decimal places for speech\r\n\
                  ;   (Sp_Modes 0-4) \r\n\
+Sp_Volume: 6     ; 0 (min) to 8 (max)\r\n\
 \r\n\
 ; Thresholds\r\n\
 \r\n\
@@ -133,8 +134,9 @@ TZ_Offset: 0     ; Timezone offset of output files in seconds\r\n\
 ;          level.\r\n\
 \r\n\
 Window:        0 ; Alarm window (m)\r\n\
+DZ_Elev:       0 ; Ground elevation (m above sea level)\r\n\
 \r\n\
-Alarm_Elev: 1000 ; Alarm elevation (m)\r\n\
+Alarm_Elev: 1000 ; Alarm elevation (m above ground level)\r\n\
 Alarm_Type:    0 ; Alarm type\r\n\
                  ;   0 = No alarm\r\n\
                  ;   1 = Beep\r\n\
@@ -180,10 +182,12 @@ static const char Config_Sp_Mode[] PROGMEM    = "Sp_Mode";
 static const char Config_Sp_Units[] PROGMEM   = "Sp_Units";
 static const char Config_Sp_Rate[] PROGMEM    = "Sp_Rate";
 static const char Config_Sp_Dec[] PROGMEM     = "Sp_Dec";
+static const char Config_Sp_Volume[] PROGMEM  = "Sp_Volume";
 static const char Config_V_Thresh[] PROGMEM   = "V_Thresh";
 static const char Config_H_Thresh[] PROGMEM   = "H_Thresh";
 static const char Config_Use_SAS[] PROGMEM    = "Use_SAS";
 static const char Config_Window[] PROGMEM     = "Window";
+static const char Config_DZ_Elev[] PROGMEM    = "DZ_Elev";
 static const char Config_Alarm_Elev[] PROGMEM = "Alarm_Elev";
 static const char Config_Alarm_Type[] PROGMEM = "Alarm_Type";
 static const char Config_Lat[] PROGMEM        = "Lat";
@@ -215,6 +219,7 @@ void Config_Read(void)
 	char    *result;
 	
 	int32_t val;
+	int32_t dz_elev;
 
 	FRESULT res;
 	
@@ -276,6 +281,7 @@ void Config_Read(void)
 		HANDLE_VALUE(Config_Sp_Units,  UBX_sp_units,     val, val >= 0 && val <= 2);
 		HANDLE_VALUE(Config_Sp_Rate,   UBX_sp_rate,      val * 1000, val >= 0 && val <= 32);
 		HANDLE_VALUE(Config_Sp_Dec,    UBX_sp_decimals,  val, val >= 0 && val <= 2);
+		HANDLE_VALUE(Config_Sp_Volume, Tone_sp_volume,   8 - val, val >= 0 && val <= 8);
 		HANDLE_VALUE(Config_V_Thresh,  UBX_threshold,    val, TRUE);
 		HANDLE_VALUE(Config_H_Thresh,  UBX_hThreshold,   val, TRUE);
 		HANDLE_VALUE(Config_Use_SAS,   UBX_use_sas,      val, val == 0 || val == 1);
@@ -287,13 +293,14 @@ void Config_Read(void)
 		HANDLE_VALUE(Config_End_Nav,   UBX_end_nav,      val, val >= 0 && val <= 3000);
 		HANDLE_VALUE(Config_Max_Dist,  UBX_max_dist,     val, val >= 0 && val <= 10000);
 		HANDLE_VALUE(Config_Min_Angle, UBX_min_angle,    val, val >= 0 && val <= 360);
+		HANDLE_VALUE(Config_DZ_Elev,   dz_elev,          val * 1000, TRUE);
 		HANDLE_VALUE(Config_TZ_Offset, Log_tz_offset,    val, TRUE);
 		
 		#undef HANDLE_VALUE
 		
 		if (!strcmp_P(name, Config_Alarm_Elev))
 		{
-			UBX_alarms[UBX_num_alarms].elev = val * 1000;
+			UBX_alarms[UBX_num_alarms].elev = val * 1000 + dz_elev;
 		}
 		if (!strcmp_P(name, Config_Alarm_Type) && val != 0)
 		{

--- a/src/Main.h
+++ b/src/Main.h
@@ -5,7 +5,7 @@
 
 #include "FatFS/ff.h"
 
-#define MAIN_DEBUG // uncomment to output timing information to PORTF
+//#define MAIN_DEBUG // uncomment to output timing information to PORTF
 
 #define MAIN_BUFFER_SIZE 1024
 

--- a/src/Tone.c
+++ b/src/Tone.c
@@ -78,7 +78,7 @@ static          uint8_t  Tone_mode;
 static          FIL      Tone_file;
 
                 uint16_t Tone_volume = 2;
-                uint16_t Tone_sp_volume = 2;
+                uint16_t Tone_sp_volume = 0;
 
 static volatile uint16_t Tone_next_index = 0;
 static volatile uint32_t Tone_next_chirp = 0; 

--- a/src/Tone.c
+++ b/src/Tone.c
@@ -78,6 +78,7 @@ static          uint8_t  Tone_mode;
 static          FIL      Tone_file;
 
                 uint16_t Tone_volume = 2;
+                uint16_t Tone_sp_volume = 2;
 
 static volatile uint16_t Tone_next_index = 0;
 static volatile uint32_t Tone_next_chirp = 0; 
@@ -226,7 +227,7 @@ static void Tone_ReadFile(
 	for (i = 0; i < br; ++i)
 	{
 		val = Main_buffer[(Tone_write + i) % TONE_BUFFER_LEN];
-		val = 128 - (128 >> Tone_volume) + (val >> Tone_volume);
+		val = 128 - (128 >> Tone_sp_volume) + (val >> Tone_sp_volume);
 		Main_buffer[(Tone_write + i) % TONE_BUFFER_LEN] = val;
 	}
 

--- a/src/Tone.c
+++ b/src/Tone.c
@@ -334,10 +334,6 @@ void Tone_Stop(void)
 
 void Tone_Task(void)
 {
-#ifdef MAIN_DEBUG
-	PORTF |= (1 << 0);
-#endif
-
 	if (Tone_flags & TONE_FLAGS_BEEP)
 	{
 		if (Tone_state == TONE_STATE_IDLE)
@@ -360,10 +356,6 @@ void Tone_Task(void)
 	{
 		Tone_Load();
 	}
-
-#ifdef MAIN_DEBUG
-	PORTF &= ~(1 << 0);
-#endif
 }
 
 void Tone_Beep(

--- a/src/Tone.c
+++ b/src/Tone.c
@@ -78,6 +78,7 @@ static          uint8_t  Tone_mode;
 static          FIL      Tone_file;
 
                 uint16_t Tone_volume = 2;
+                uint16_t Tone_sp_volume = 2;
 
 static volatile uint16_t Tone_next_index = 0;
 static volatile uint32_t Tone_next_chirp = 0; 
@@ -219,7 +220,7 @@ static void Tone_ReadFile(
 	for (i = 0; i < br; ++i)
 	{
 		val = Main_buffer[(Tone_write + i) % TONE_BUFFER_LEN];
-		val = 128 - (128 >> Tone_volume) + (val >> Tone_volume);
+		val = 128 - (128 >> Tone_sp_volume) + (val >> Tone_sp_volume);
 		Main_buffer[(Tone_write + i) % TONE_BUFFER_LEN] = val;
 	}
 
@@ -334,10 +335,6 @@ void Tone_Stop(void)
 
 void Tone_Task(void)
 {
-#ifdef MAIN_DEBUG
-	PORTF |= (1 << 0);
-#endif
-
 	if (Tone_flags & TONE_FLAGS_BEEP)
 	{
 		if (Tone_state == TONE_STATE_IDLE)
@@ -360,10 +357,6 @@ void Tone_Task(void)
 	{
 		Tone_Load();
 	}
-
-#ifdef MAIN_DEBUG
-	PORTF &= ~(1 << 0);
-#endif
 }
 
 void Tone_Beep(

--- a/src/Tone.h
+++ b/src/Tone.h
@@ -12,6 +12,7 @@
 #define TONE_CHIRP_MAX     (((uint32_t) 3242 << 16) / TONE_LENGTH_125_MS)
 
 extern uint16_t Tone_volume;
+extern uint16_t Tone_sp_volume;
 
 void Tone_Init(void);
 void Tone_Update(void);

--- a/src/Tone.h
+++ b/src/Tone.h
@@ -14,6 +14,7 @@
 #define TONE_CHIRP_MAX     (((uint32_t) 3242 << 16) / TONE_LENGTH_125_MS)
 
 extern uint16_t Tone_volume;
+extern uint16_t Tone_sp_volume;
 
 void Tone_Init(void);
 void Tone_Update(void);

--- a/src/UBX.c
+++ b/src/UBX.c
@@ -322,17 +322,16 @@ void UBX_Update(void)
 	
 	if (state == st_blinking)
 	{
-		if (counter == 100)
+		if (counter == 0)
 		{
 			LEDs_ChangeLEDs(LEDS_ALL_LEDS, 0);
 		}
-		else if (counter == 1000)
+		else if (counter == 900)
 		{
 			LEDs_ChangeLEDs(LEDS_ALL_LEDS, Main_activeLED);
-			counter = 0;
 		}
 
-		++counter;
+		counter = (counter + 1) % 1000;
 	}
 }
 

--- a/src/UBX.c
+++ b/src/UBX.c
@@ -1092,10 +1092,6 @@ void UBX_Task(void)
 	UBX_saved_t *current;
 	char *ptr;
 
-#ifdef MAIN_DEBUG
-	PORTF |= (1 << 1);
-#endif
-
 	while (!((ch = uart_getc()) & UART_NO_DATA))
 	{
 		if (UBX_HandleByte(ch))
@@ -1192,8 +1188,4 @@ void UBX_Task(void)
 		
 		++UBX_speech_ptr;
 	}
-
-#ifdef MAIN_DEBUG
-	PORTF &= ~(1 << 1);
-#endif
 }

--- a/src/UBX.c
+++ b/src/UBX.c
@@ -316,9 +316,12 @@ static UBX_saved_t UBX_saved[UBX_BUFFER_LEN];
 static uint8_t UBX_read  = 0;
 static uint8_t UBX_write = 0;
 
-static volatile uint8_t UBX_hasFix        = 0;
-static volatile uint8_t UBX_prevFix       = 0;
-static          uint8_t UBX_suppress_tone = 0;
+static volatile uint8_t UBX_hasFix = 0;
+
+static uint8_t UBX_prevFix = 0;
+static int32_t UBX_prevHMSL;
+
+static uint8_t UBX_suppress_tone = 0;
 
 static char UBX_speech_buf[16] = "\0";
 static char *UBX_speech_ptr = UBX_speech_buf;
@@ -561,49 +564,6 @@ static void UBX_SendMessage(
 	uart_putc(ck_b);
 }
 
-static void UBX_ReceiveMessage(
-	uint8_t msg_received, 
-	uint32_t time_of_week)
-{
-	UBX_saved_t *current = UBX_saved + (UBX_write % UBX_BUFFER_LEN);
-
-	if (time_of_week != UBX_time_of_week)
-	{
-		UBX_time_of_week = time_of_week;
-		UBX_msg_received = 0;
-	}
-
-	UBX_msg_received |= msg_received;
-
-	if (UBX_msg_received == UBX_MSG_ALL)
-	{
-		if (current->nav_sol.gpsFix == 3)
-		{
-			if (!Log_IsInitialized())
-			{
-				Power_Hold();
-
-				Log_Init(
-					current->nav_timeutc.year,
-					current->nav_timeutc.month,
-					current->nav_timeutc.day,
-					current->nav_timeutc.hour,
-					current->nav_timeutc.min,
-					current->nav_timeutc.sec);
-
-				Log_WriteString(UBX_header);
-				UBX_state = st_flush_1;
-
-				Tone_Beep(TONE_MAX_PITCH - 1, 0, TONE_LENGTH_125_MS);
-			}
-			
-			++UBX_write;
-		}
-
-		UBX_msg_received = 0;
-	}
-}
-
 static void UBX_SetTone(
 	int32_t val_1,
 	int32_t min_1,
@@ -687,107 +647,13 @@ static void UBX_SetTone(
 	#undef UNDER
 }
 
-static void UBX_HandleNavSol(void)
-{
-	UBX_saved_t *current = UBX_saved + (UBX_write % UBX_BUFFER_LEN);
-	
-	current->nav_sol = *((UBX_nav_sol *) UBX_payload);
-	UBX_ReceiveMessage(UBX_MSG_SOL, current->nav_sol.iTOW);
-
-	UBX_prevFix = UBX_hasFix;
-
-	if (current->nav_sol.gpsFix == 0x03)
-	{
-		UBX_hasFix = 1;
-	}
-	else
-	{
-		UBX_SetTone(UBX_INVALID_VALUE, 0, 0, 0, 0, 0);
-		UBX_hasFix = 0;
-	}
-}
-
-static void UBX_HandlePosition(void)
-{
-	UBX_saved_t *current = UBX_saved + (UBX_write % UBX_BUFFER_LEN);
-	
-	const int32_t prev_hMSL = current->nav_pos_llh.hMSL;
-	int32_t hMSL;
-	
-	uint8_t i, suppress_tone;
-
-	current->nav_pos_llh = *((UBX_nav_posllh *) UBX_payload);
-	UBX_ReceiveMessage(UBX_MSG_POSLLH, current->nav_pos_llh.iTOW);
-
-	hMSL = current->nav_pos_llh.hMSL;
-
-	if (UBX_hasFix && UBX_prevFix)
-	{
-		int32_t min = MIN(prev_hMSL, hMSL);
-		int32_t max = MAX(prev_hMSL, hMSL);
-
-		int i;
-	
-		for (i = 0; i < UBX_num_alarms; ++i)
-		{
-			const int32_t elev = UBX_alarms[i].elev;
-		
-			if (elev >= min && elev <  max)
-			{
-				switch (UBX_alarms[i].type)
-				{
-				case 1:	// beep
-					Tone_Beep(TONE_MAX_PITCH - 1, 0, TONE_LENGTH_125_MS);
-					break ;
-				case 2:	// chirp up
-					Tone_Beep(0, TONE_CHIRP_MAX, TONE_LENGTH_125_MS);
-					break ;
-				case 3:	// chirp down
-					Tone_Beep(TONE_MAX_PITCH - 1, -TONE_CHIRP_MAX, TONE_LENGTH_125_MS);
-					break ;
-				case 4:	// warble
-					Tone_Beep(0, 5 * TONE_CHIRP_MAX, TONE_LENGTH_125_MS);
-					break ;
-				}
-				
-				break;
-			}
-		}
-	}
-
-	if (UBX_hasFix)
-	{
-		suppress_tone = 0;
-	
-		for (i = 0; i < UBX_num_alarms; ++i)
-		{
-			const int32_t diff = UBX_alarms[i].elev - current->nav_pos_llh.hMSL;
-		
-			if (ABS (diff) < UBX_alarm_window)
-			{
-				suppress_tone = 1;
-				break;
-			}
-		}
-		
-		if (suppress_tone && !UBX_suppress_tone)
-		{
-			Tone_SetRate(0);
-			Tone_Stop();
-		}
-		
-		UBX_suppress_tone = suppress_tone;
-	}
-}
-
 static void UBX_GetValues(
+	UBX_saved_t *current,
 	uint8_t mode, 
 	int32_t *val, 
 	int32_t *min, 
 	int32_t *max)
 {
-	UBX_saved_t *current = UBX_saved + (UBX_write % UBX_BUFFER_LEN);
-
 	uint16_t speed_mul = 1024;
 
 	if (UBX_use_sas)
@@ -949,10 +815,9 @@ static void UBX_GetValues(
 	}
 }
 
-static void UBX_SpeakValue(void)
+static void UBX_SpeakValue(
+	UBX_saved_t *current)
 {
-	UBX_saved_t *current = UBX_saved + (UBX_write % UBX_BUFFER_LEN);
-
 	uint16_t speed_mul = 1024;
     
 	char *end_ptr;
@@ -1122,28 +987,72 @@ static void UBX_SpeakValue(void)
 	
 }
 
-static void UBX_HandleVelocity(void)
+static void UBX_UpdateAlarms(
+	UBX_saved_t *current)
 {
-	static int32_t x0 = -1, x1, x2;
+	uint8_t i, suppress_tone;
+
+	suppress_tone = 0;
+
+	for (i = 0; i < UBX_num_alarms; ++i)
+	{
+		if (ABS (UBX_alarms[i].elev - current->nav_pos_llh.hMSL) < UBX_alarm_window)
+		{
+			suppress_tone = 1;
+			break;
+		}
+	}
+	
+	if (suppress_tone && !UBX_suppress_tone)
+	{
+		Tone_SetRate(0);
+		Tone_Stop();
+	}
+	
+	UBX_suppress_tone = suppress_tone;
+
+	if (UBX_prevFix)
+	{
+		int32_t min = MIN(UBX_prevHMSL, current->nav_pos_llh.hMSL);
+		int32_t max = MAX(UBX_prevHMSL, current->nav_pos_llh.hMSL);
+
+		for (i = 0; i < UBX_num_alarms; ++i)
+		{
+			const int32_t elev = UBX_alarms[i].elev;
+		
+			if (elev >= min && elev <  max)
+			{
+				switch (UBX_alarms[i].type)
+				{
+				case 1:	// beep
+					Tone_Beep(TONE_MAX_PITCH - 1, 0, TONE_LENGTH_125_MS);
+					break ;
+				case 2:	// chirp up
+					Tone_Beep(0, TONE_CHIRP_MAX, TONE_LENGTH_125_MS);
+					break ;
+				case 3:	// chirp down
+					Tone_Beep(TONE_MAX_PITCH - 1, -TONE_CHIRP_MAX, TONE_LENGTH_125_MS);
+					break ;
+				case 4:	// warble
+					Tone_Beep(0, 5 * TONE_CHIRP_MAX, TONE_LENGTH_125_MS);
+					break ;
+				}
+				
+				break;
+			}
+		}
+	}
+}
+
+static void UBX_UpdateTones(
+	UBX_saved_t *current)
+{
+	static int32_t x0 = UBX_INVALID_VALUE, x1, x2;
 	
 	int32_t val_1 = UBX_INVALID_VALUE, min_1 = UBX_min, max_1 = UBX_max;
 	int32_t val_2 = UBX_INVALID_VALUE, min_2 = UBX_min_2, max_2 = UBX_max_2;
 
-	UBX_saved_t *current = UBX_saved + (UBX_write % UBX_BUFFER_LEN);
-	
-	current->nav_velned = *((UBX_nav_velned *) UBX_payload);
-	UBX_ReceiveMessage(UBX_MSG_VELNED, current->nav_velned.iTOW);
-
-	if (ABS(current->nav_velned.velD) >= UBX_threshold && 
-	    current->nav_velned.gSpeed >= UBX_hThreshold)
-	{
-		UBX_GetValues(UBX_mode,   &val_1, &min_1, &max_1);
-		UBX_GetValues(UBX_mode_2, &val_2, &min_2, &max_2);
-	}
-	else
-	{
-		UBX_sp_counter = 0;
-	}
+	UBX_GetValues(current, UBX_mode, &val_1, &min_1, &max_1);
 
 	switch (UBX_mode_2)
 	{
@@ -1198,25 +1107,111 @@ static void UBX_HandleVelocity(void)
 		UBX_GetValues(UBX_mode_2, &val_2, &min_2, &max_2);
 	}
 
-	if (UBX_hasFix && !UBX_suppress_tone)
+	if (!UBX_suppress_tone)
 	{
-		UBX_SetTone(val_1, min_1, max_1, val_2, min_2, max_2);
-			
-		if (UBX_sp_rate != 0 && 
-		    UBX_sp_counter >= UBX_sp_rate)
+		if (ABS(current->nav_velned.velD) >= UBX_threshold && 
+			current->nav_velned.gSpeed >= UBX_hThreshold)
 		{
-			UBX_SpeakValue();
-			UBX_sp_counter = 0;
+			UBX_SetTone(val_1, min_1, max_1, val_2, min_2, max_2);
+				
+			if (UBX_sp_rate != 0 && UBX_sp_counter >= UBX_sp_rate)
+			{
+				UBX_SpeakValue(current);
+				UBX_sp_counter = 0;
+			}
+		}
+		else
+		{
+			Tone_SetRate(0);
 		}
 	}
 
-	UBX_sp_counter += UBX_rate;
+	if (UBX_sp_counter < UBX_sp_rate)
+	{
+		UBX_sp_counter += UBX_rate;
+	}
+}
+
+static void UBX_ReceiveMessage(
+	uint8_t msg_received, 
+	uint32_t time_of_week)
+{
+	UBX_saved_t *current = UBX_saved + (UBX_write % UBX_BUFFER_LEN);
+
+	if (time_of_week != UBX_time_of_week)
+	{
+		UBX_time_of_week = time_of_week;
+		UBX_msg_received = 0;
+	}
+
+	UBX_msg_received |= msg_received;
+
+	if (UBX_msg_received == UBX_MSG_ALL)
+	{
+		if (current->nav_sol.gpsFix == 0x03)
+		{
+			UBX_hasFix = 1;
+
+			UBX_UpdateAlarms(current);
+			UBX_UpdateTones(current);
+
+			if (!Log_IsInitialized())
+			{
+				Power_Hold();
+
+				Log_Init(
+					current->nav_timeutc.year,
+					current->nav_timeutc.month,
+					current->nav_timeutc.day,
+					current->nav_timeutc.hour,
+					current->nav_timeutc.min,
+					current->nav_timeutc.sec);
+
+				Log_WriteString(UBX_header);
+				UBX_state = st_flush_1;
+
+				Tone_Beep(TONE_MAX_PITCH - 1, 0, TONE_LENGTH_125_MS);
+			}
+
+			++UBX_write;
+		}
+		else
+		{
+			UBX_hasFix = 0;
+			Tone_SetRate(0);
+		}
+
+		UBX_prevFix = UBX_hasFix;
+		UBX_prevHMSL = current->nav_pos_llh.hMSL;
+		
+		UBX_msg_received = 0;
+	}
+}
+
+static void UBX_HandleNavSol(void)
+{
+	UBX_saved_t *current = UBX_saved + (UBX_write % UBX_BUFFER_LEN);
+	current->nav_sol = *((UBX_nav_sol *) UBX_payload);
+	UBX_ReceiveMessage(UBX_MSG_SOL, current->nav_sol.iTOW);
+}
+
+static void UBX_HandlePosition(void)
+{
+	UBX_saved_t *current = UBX_saved + (UBX_write % UBX_BUFFER_LEN);
+	current->nav_pos_llh = *((UBX_nav_posllh *) UBX_payload);
+	UBX_ReceiveMessage(UBX_MSG_POSLLH, current->nav_pos_llh.iTOW);
+}
+
+static void UBX_HandleVelocity(void)
+{
+	UBX_saved_t *current = UBX_saved + (UBX_write % UBX_BUFFER_LEN);
+	current->nav_velned = *((UBX_nav_velned *) UBX_payload);
+	UBX_ReceiveMessage(UBX_MSG_VELNED, current->nav_velned.iTOW);
 }
 
 static void UBX_HandleTimeUTC(void)
 {
 	UBX_saved_t *current = UBX_saved + (UBX_write % UBX_BUFFER_LEN);
-	
 	current->nav_timeutc = *((UBX_nav_timeutc *) UBX_payload);
 	UBX_ReceiveMessage(UBX_MSG_TIMEUTC, current->nav_timeutc.iTOW);
 }
@@ -1350,10 +1345,6 @@ void UBX_Task(void)
 
 	UBX_saved_t *current;
 	char *ptr;
-
-#ifdef MAIN_DEBUG
-	PORTF |= (1 << 1);
-#endif
 
 	while (!((ch = uart_getc()) & UART_NO_DATA))
 	{
@@ -1494,8 +1485,4 @@ void UBX_Task(void)
 		}
 		++UBX_speech_ptr;
 	}
-
-#ifdef MAIN_DEBUG
-	PORTF &= ~(1 << 1);
-#endif
 }


### PR DESCRIPTION
Merged changes from the main repository:
- Added a separate volume control for speech.
- Alarms are relative to ground elevation, rather than sea level. Ground elevation is specified separately in the configuration file.
- Instead of processing UBX messages as they arrive, we now process everything once a complete set of UBX messages has been received.
- Green LED turns off immediately when the log file begins. This allows us to accurately synchronize video with the FlySight log.

You might consider merging the `DZ_Elev` and `Elevation` configuration parameters, but I thought I would leave this for now since I thought it would be confusing to have the ground elevation specified in the FlyBlind parameters separately from the alarm parameters.
