### PR TITLE
Timezone offset to int32

### DIFF
--- a/src/Log.c
+++ b/src/Log.c
@@ -13,7 +13,7 @@
 
 #define FILE_NUMBER_ADDR 0
 
-int16_t Log_tz_offset = 0;
+int32_t Log_tz_offset = 0;
 
 static uint8_t Log_initialized = 0;
 static DWORD   Log_fattime;

--- a/src/Log.h
+++ b/src/Log.h
@@ -3,7 +3,7 @@
 
 extern uint8_t Log_enable_raw;
 extern uint8_t Log_enable_csv;
-extern int16_t Log_tz_offset;
+extern int32_t Log_tz_offset;
 
 void Log_Flush(void);
 void Log_WriteChar(char ch);


### PR DESCRIPTION
Timezone offset was previously stored as int16, which doesn't handle offsets greater than 9 hours (e.g., New Zealand).
