### PR TITLE
Speech alarms

### DIFF
--- a/src/Config.c
+++ b/src/Config.c
@@ -274,7 +274,7 @@ void Config_Read(void)
 		}
 		if (!strcmp_P(name, Config_Alarm_File) && val != 0)
 		{
-			strcpy(UBX_alarms[UBX_num_alarms - 1].filename, val);
+			strcpy(UBX_alarms[UBX_num_alarms - 1].filename, result);
 		}
 	}
 	

--- a/src/Config.c
+++ b/src/Config.c
@@ -17,6 +17,9 @@
 static const char Config_default[] PROGMEM = "\
 ; Firmware version " FLYSIGHT_VERSION "\r\n\
 \r\n\
+; For information on configuring FlySight, please go to\r\n\
+;     http://flysight.ca/wiki\r\n\
+\r\n\
 ; GPS settings\r\n\
 \r\n\
 Model:     6     ; Dynamic model\r\n\
@@ -118,13 +121,13 @@ TZ_Offset: 0     ; Timezone offset of output files in seconds\r\n\
 ;          UNDER NO CIRCUMSTANCES SHOULD THESE ALARMS BE\r\n\
 ;          USED TO INDICATE DEPLOYMENT OR BREAKOFF ALTITUDE.\r\n\
 \r\n\
-; NOTE:    Alarm elevations are given in meters above sea\r\n\
-;          level.\r\n\
+; NOTE:    Alarm elevations are given in meters above ground\r\n\
+;          elevation, which is specified in DZ_Elev.\r\n\
 \r\n\
 Window:        0 ; Alarm window (m)\r\n\
 DZ_Elev:       0 ; Ground elevation (m above sea level)\r\n\
 \r\n\
-Alarm_Elev: 1000 ; Alarm elevation (m above ground level)\r\n\
+Alarm_Elev:    0 ; Alarm elevation (m above ground level)\r\n\
 Alarm_Type:    0 ; Alarm type\r\n\
                  ;   0 = No alarm\r\n\
                  ;   1 = Beep\r\n\

--- a/src/Config.c
+++ b/src/Config.c
@@ -129,8 +129,7 @@ Alarm_Type:    0 ; Alarm type\r\n\
                  ;   0 = No alarm\r\n\
                  ;   1 = Beep\r\n\
                  ;   2 = Chirp up\r\n\
-                 ;   3 = Chirp down\r\n\
-                 ;   4 = Warble\r\n";
+                 ;   3 = Chirp down\r\n";
 
 static const char Config_Model[] PROGMEM      = "Model";
 static const char Config_Rate[] PROGMEM       = "Rate";

--- a/src/Config.c
+++ b/src/Config.c
@@ -109,6 +109,9 @@ TZ_Offset: 0     ; Timezone offset of output files in seconds\r\n\
                  ;   -21600 = UTC-6 (CST, MDT)\r\n\
                  ;   -25200 = UTC-7 (MST, PDT)\r\n\
                  ;   -28800 = UTC-8 (PST)\r\n\
+Sp_Test:   0     ; Run speech test\r\n\
+                 ;   0 = No\r\n\
+                 ;   1 = Yes\r\n\
 \r\n\
 \r\n\
 ; Alarm settings\r\n\
@@ -160,6 +163,7 @@ static const char Config_DZ_Elev[] PROGMEM    = "DZ_Elev";
 static const char Config_Alarm_Elev[] PROGMEM = "Alarm_Elev";
 static const char Config_Alarm_Type[] PROGMEM = "Alarm_Type";
 static const char Config_TZ_Offset[] PROGMEM  = "TZ_Offset";
+static const char Config_Sp_Test[] PROGMEM    = "Sp_Test";
 
 static void Config_WriteString_P(
 	const char *str,
@@ -250,6 +254,7 @@ void Config_Read(void)
 		HANDLE_VALUE(Config_Window,    UBX_alarm_window, val * 1000, TRUE);
 		HANDLE_VALUE(Config_DZ_Elev,   dz_elev,          val * 1000, TRUE);
 		HANDLE_VALUE(Config_TZ_Offset, Log_tz_offset,    val, TRUE);
+		HANDLE_VALUE(Config_Sp_Test,   UBX_sp_test,      val, val == 0 || val == 1);
 		
 		#undef HANDLE_VALUE
 		

--- a/src/Config.c
+++ b/src/Config.c
@@ -135,7 +135,9 @@ Alarm_Type:    0 ; Alarm type\r\n\
                  ;   0 = No alarm\r\n\
                  ;   1 = Beep\r\n\
                  ;   2 = Chirp up\r\n\
-                 ;   3 = Chirp down\r\n";
+                 ;   3 = Chirp down\r\n\
+                 ;   4 = Play file\r\n\
+Alarm_File:    0 ; File to be played\r\n";
 
 static const char Config_Model[] PROGMEM      = "Model";
 static const char Config_Rate[] PROGMEM       = "Rate";
@@ -162,6 +164,7 @@ static const char Config_Window[] PROGMEM     = "Window";
 static const char Config_DZ_Elev[] PROGMEM    = "DZ_Elev";
 static const char Config_Alarm_Elev[] PROGMEM = "Alarm_Elev";
 static const char Config_Alarm_Type[] PROGMEM = "Alarm_Type";
+static const char Config_Alarm_File[] PROGMEM = "Alarm_File";
 static const char Config_TZ_Offset[] PROGMEM  = "TZ_Offset";
 static const char Config_Sp_Test[] PROGMEM    = "Sp_Test";
 
@@ -260,12 +263,18 @@ void Config_Read(void)
 		
 		if (!strcmp_P(name, Config_Alarm_Elev))
 		{
-			UBX_alarms[UBX_num_alarms].elev = val * 1000 + dz_elev;
+			++UBX_num_alarms;
+			UBX_alarms[UBX_num_alarms - 1].elev = val * 1000 + dz_elev;
+			UBX_alarms[UBX_num_alarms - 1].type = 0;
+			UBX_alarms[UBX_num_alarms - 1].filename[0] = '\0';
 		}
 		if (!strcmp_P(name, Config_Alarm_Type) && val != 0)
 		{
-			UBX_alarms[UBX_num_alarms].type = val;
-			++UBX_num_alarms;
+			UBX_alarms[UBX_num_alarms - 1].type = val;
+		}
+		if (!strcmp_P(name, Config_Alarm_File) && val != 0)
+		{
+			strcpy(UBX_alarms[UBX_num_alarms - 1].filename, val);
 		}
 	}
 	

--- a/src/UBX.c
+++ b/src/UBX.c
@@ -245,6 +245,7 @@ uint8_t  UBX_sp_mode       = 2;
 uint8_t  UBX_sp_units      = UBX_UNITS_MPH;
 uint16_t UBX_sp_rate       = 0;
 uint8_t  UBX_sp_decimals   = 0;
+uint8_t  UBX_sp_test       = 0;
 
 static uint16_t UBX_sp_counter = 0;
 
@@ -914,7 +915,27 @@ static void UBX_ReceiveMessage(
 				Log_WriteString(UBX_header);
 				UBX_state = st_flush_1;
 
-				Tone_Beep(TONE_MAX_PITCH - 1, 0, TONE_LENGTH_125_MS);
+				if (UBX_sp_test)
+				{
+					UBX_speech_buf[0] = '0';
+					UBX_speech_buf[1] = '1';
+					UBX_speech_buf[2] = '2';
+					UBX_speech_buf[3] = '3';
+					UBX_speech_buf[4] = '4';
+					UBX_speech_buf[5] = '5';
+					UBX_speech_buf[6] = '6';
+					UBX_speech_buf[7] = '7';
+					UBX_speech_buf[8] = '8';
+					UBX_speech_buf[9] = '9';
+					UBX_speech_buf[10] = '.';
+					UBX_speech_buf[11] = '-';
+					UBX_speech_buf[12] = 0;
+					UBX_speech_ptr = UBX_speech_buf;
+				}
+				else
+				{
+					Tone_Beep(TONE_MAX_PITCH - 1, 0, TONE_LENGTH_125_MS);
+				}
 			}
 
 			++UBX_write;

--- a/src/UBX.c
+++ b/src/UBX.c
@@ -259,6 +259,8 @@ uint32_t  UBX_alarm_window = 0;
 static uint32_t UBX_time_of_week = 0;
 static uint8_t  UBX_msg_received = 0;
 
+static char UBX_buf[150];
+
 typedef struct
 {
 	int32_t  lon;      // Longitude                    (deg)
@@ -828,6 +830,11 @@ static void UBX_UpdateAlarms(
 				case 3:	// chirp down
 					Tone_Beep(TONE_MAX_PITCH - 1, -TONE_CHIRP_MAX, TONE_LENGTH_125_MS);
 					break ;
+				case 4:	// play file
+					strcpy(UBX_buf, UBX_alarms[i].filename);
+					strcat(UBX_buf, ".wav");
+					Tone_Play(UBX_buf);
+					break;
 				}
 				
 				break;
@@ -1155,8 +1162,6 @@ void UBX_Init(void)
 
 void UBX_Task(void)
 {
-	static char buf[150];
-
 	unsigned int ch;
 
 	UBX_saved_t *current;
@@ -1179,7 +1184,7 @@ void UBX_Task(void)
 
 			Power_Hold();
 
-			ptr = buf + sizeof(buf);
+			ptr = UBX_buf + sizeof(UBX_buf);
 			*(--ptr) = 0;
 
 			*(--ptr) = '\n';
@@ -1250,14 +1255,14 @@ void UBX_Task(void)
 			}
 			else
 			{
-				buf[0] = *UBX_speech_ptr;
-				buf[1] = '.';
-				buf[2] = 'w';
-				buf[3] = 'a';
-				buf[4] = 'v';
-				buf[5] = 0;
+				UBX_buf[0] = *UBX_speech_ptr;
+				UBX_buf[1] = '.';
+				UBX_buf[2] = 'w';
+				UBX_buf[3] = 'a';
+				UBX_buf[4] = 'v';
+				UBX_buf[5] = 0;
 				
-				Tone_Play(buf);
+				Tone_Play(UBX_buf);
 			}
 			
 			++UBX_speech_ptr;

--- a/src/UBX.c
+++ b/src/UBX.c
@@ -806,9 +806,6 @@ static void UBX_UpdateAlarms(
 				case 3:	// chirp down
 					Tone_Beep(TONE_MAX_PITCH - 1, -TONE_CHIRP_MAX, TONE_LENGTH_125_MS);
 					break ;
-				case 4:	// warble
-					Tone_Beep(0, 5 * TONE_CHIRP_MAX, TONE_LENGTH_125_MS);
-					break ;
 				}
 				
 				break;

--- a/src/UBX.h
+++ b/src/UBX.h
@@ -38,6 +38,7 @@ extern uint8_t   UBX_sp_mode;
 extern uint8_t   UBX_sp_units;
 extern uint16_t  UBX_sp_rate;
 extern uint8_t   UBX_sp_decimals;
+extern uint8_t   UBX_sp_test;
 
 void UBX_Init(void);
 void UBX_Task(void);

--- a/src/UBX.h
+++ b/src/UBX.h
@@ -9,6 +9,7 @@ typedef struct
 {
 	int32_t elev;
 	uint8_t type;
+	char    filename[9];
 }
 UBX_alarm;
 


### PR DESCRIPTION
Reviving a pull request that I had submitted previously but accidentally killed the branch...

Added the option to play a WAV file when an elevation alarm is triggered, instead of playing a tone. The file is specified by the "Alarm_File" configuration option, and does not include the path (the `audio` folder on the FlySight) or extension (always `.wav`). It should be 8 characters or less. For example, consider the following lines in the `config.txt` file:

```
Alarm_Elev: 2000 ; Alarm elevation (m above ground level)
Alarm_Type:    4 ; Alarm type
Alarm_File:    1 ; File to be played
```

This will play `audio/1.wav` at 2000 m AGL. As always, files should be recorded at a rate of 7812 Hz with one 8-bit unsigned channel.
